### PR TITLE
Update interfaces.yaml

### DIFF
--- a/interfaces.yaml
+++ b/interfaces.yaml
@@ -1,7 +1,5 @@
 2023 Fellowship Candidates:
-  Representative:Andy Twelves
-  Email: andrew@wyza.uk
-  Onboarding: +447377260715
+  Representative: Richard Hames
 
   Richard's Account Details (Do not change)
   Account Number: 93245677


### PR DESCRIPTION
Rep terms are 2 weeks long, pursuant to https://docs.google.com/document/d/1xPQx-xckIx5qEtN4EQZySHjWNnGiW-1pNoi-zYrPk_A/edit?usp=drivesdk

Andy's term started on 14 April 2024, 2 weeks ago. According to the rep rotation shared by Andy in our discord, Richard is next to be Rep, thus his term starts today and ends on 12 May, 2024